### PR TITLE
Fixed 2 typos in README.md file

### DIFF
--- a/next-api/README.md
+++ b/next-api/README.md
@@ -1,10 +1,10 @@
 > # **API Routes in NextJs**
 
-* API roting mechanism is similar to page based routing mechanism
+* API routing mechanism is similar to page based routing mechanism
 * APIs are associated with a route based on their file name
 * Every API route exports a default function typically named as handler function
 * The handler function receives the request and response as parameters
 * Cater to different request types like GET, POST and DELETE using req.method
 * Dynamic API Routes
 * Catch all API Routes
-* We should not call our own API routes for pre-rendring content 
+* We should not call our own API routes for pre-rendering content 


### PR DESCRIPTION
1. Typo 1: **roting** changed to **routing** in first point.

`-  API **roting** mechanism is similar to page based routing mechanism`
`+ API **routing** mechanism is similar to page based routing mechanism`

2. Typo 2: **rendring** changed to **rendering** in eighth point.

`- We should not call our own API routes for pre-**rendring** content `
`+ We should not call our own API routes for pre-**rendering** content `
